### PR TITLE
Fixed regression in imports

### DIFF
--- a/ckanext/requestdata/controllers/package.py
+++ b/ckanext/requestdata/controllers/package.py
@@ -12,7 +12,12 @@ get_action = logic.get_action
 NotAuthorized = logic.NotAuthorized
 ValidationError = logic.ValidationError
 clean_dict = logic.clean_dict
-redirect = base.redirect
+try:
+    # Support CKAN 2.6
+    redirect = base.redirect
+except AttributeError:
+    # Redirect is now redirect_to in CKAN 2.7
+    redirect = h.redirect_to
 abort = base.abort
 tuplize_dict = logic.tuplize_dict
 parse_params = logic.parse_params


### PR DESCRIPTION
## Description
In CKAN 2.6 the function `redirect` is a member of `ckan.lib.base`. This function was removed in CKAN 2.7. However, a function with a similar functionality and compatible interface has been introduced. This new function is defined in `ckan.lib.helpers` and is named `redirect_to`.

The present implementation of this extension raises an `AttributeError` exception whenever the package controller module is executed with CKAN 2.7. This PR wraps the references to `base.redirect` in a `try...except...` falling back to the CKAN 2.7 function.

NB: The fix in this PR has already been implemented in the upstream repository at https://github.com/ViderumGlobal/ckanext-requestdata